### PR TITLE
docs: Remove Discord references

### DIFF
--- a/docs/SETUP_AND_TROUBLESHOOTING.md
+++ b/docs/SETUP_AND_TROUBLESHOOTING.md
@@ -376,8 +376,7 @@ pytest tests/
 If you continue to experience issues:
 
 1. Check the [GitHub Issues](https://github.com/itdojp/req2run-benchmark/issues)
-2. Join our [Discord Community](https://discord.gg/req2run)
-3. Contact support: contact@itdo.jp
+2. Contact support: contact@itdo.jp
 
 ---
 
@@ -518,5 +517,4 @@ pytest tests/
 問題が続く場合：
 
 1. [GitHubイシュー](https://github.com/itdojp/req2run-benchmark/issues)を確認
-2. [Discordコミュニティ](https://discord.gg/req2run)に参加
-3. サポートに連絡: contact@itdo.jp
+2. サポートに連絡: contact@itdo.jp

--- a/docs/SYSTEM_OVERVIEW.md
+++ b/docs/SYSTEM_OVERVIEW.md
@@ -406,7 +406,6 @@ graph TB
 ### Resources (リソース)
 - 📖 [Documentation](https://docs.req2run.io)
 - 💙 [GitHub Repository](https://github.com/itdojp/req2run-benchmark)
-- 💬 [Discord Community](https://discord.gg/req2run)
 - 📧 [Email Support](mailto:contact@itdo.jp)
 
 ### Contributing (貢献)

--- a/docs/USAGE_GUIDE.md
+++ b/docs/USAGE_GUIDE.md
@@ -568,7 +568,6 @@ req2run doctor
 
 ### Community
 - [GitHub Discussions](https://github.com/itdojp/req2run-benchmark/discussions)
-- [Discord Server](https://discord.gg/req2run)
 - [Stack Overflow Tag](https://stackoverflow.com/questions/tagged/req2run)
 
 ### Contact

--- a/docs/ufai/COMPLIANCE_LEVELS.md
+++ b/docs/ufai/COMPLIANCE_LEVELS.md
@@ -393,5 +393,5 @@ For L4 and L5 compliance:
 
 - **Documentation**: https://bench.req2run.io/docs
 - **Examples**: https://github.com/req2run/examples
-- **Community**: https://discord.gg/req2run
+- **Community**: GitHub Discussions
 - **Email**: support@req2run.io

--- a/docs/ufai/DEVELOPER_GUIDE.md
+++ b/docs/ufai/DEVELOPER_GUIDE.md
@@ -1122,7 +1122,7 @@ mypy adapters/universal/
 - **GitHub Issues**: https://github.com/itdojp/req2run-benchmark/issues
 - **Documentation**: https://github.com/itdojp/req2run-benchmark/tree/main/docs/ufai
 - **Examples**: https://github.com/itdojp/req2run-benchmark/tree/main/adapters/examples
-- **Community Discord**: (Coming soon)
+- **Community**: GitHub Discussions
 
 ---
 

--- a/docs/ufai/INTEGRATION_GUIDE.md
+++ b/docs/ufai/INTEGRATION_GUIDE.md
@@ -566,8 +566,7 @@ bench all --dry-run
 - **Examples**: https://github.com/req2run/examples
 
 ### Community
-- **Discord**: https://discord.gg/req2run
-- **Forum**: https://forum.req2run.io
+- **GitHub Discussions**: https://github.com/itdojp/req2run-benchmark/discussions
 - **Stack Overflow**: Tag with `ufai-benchmark`
 
 ### Getting Help

--- a/docs/ufai/QUICK_START.md
+++ b/docs/ufai/QUICK_START.md
@@ -488,7 +488,7 @@ Now that you have your first benchmark running:
 - **Full Documentation**: [Developer Guide](DEVELOPER_GUIDE.md) | [User Guide](USER_GUIDE.md)
 - **Examples**: [/adapters/examples](../../adapters/examples)
 - **Support**: [GitHub Issues](https://github.com/itdojp/req2run-benchmark/issues)
-- **Community**: Discord (Coming Soon)
+- **Community**: GitHub Discussions
 
 ---
 

--- a/docs/ufai/USER_GUIDE.md
+++ b/docs/ufai/USER_GUIDE.md
@@ -796,7 +796,7 @@ commands:
 - **Documentation**: https://github.com/itdojp/req2run-benchmark/docs/ufai
 - **Examples**: https://github.com/itdojp/req2run-benchmark/adapters/examples
 - **Issues**: https://github.com/itdojp/req2run-benchmark/issues
-- **Community**: Discord (coming soon)
+- **Community**: GitHub Discussions
 
 ---
 


### PR DESCRIPTION
## Summary

This PR removes all Discord references from the documentation since Discord is not being used for this project.

## Changes

- Removed Discord invite links (`https://discord.gg/req2run`) from all documentation
- Replaced Discord references with GitHub Discussions as the community platform
- Updated support sections to prioritize GitHub Issues and email contact

## Files Modified

- `docs/SETUP_AND_TROUBLESHOOTING.md` - Removed Discord from support section
- `docs/SYSTEM_OVERVIEW.md` - Removed Discord from resources
- `docs/USAGE_GUIDE.md` - Removed Discord server link
- `docs/ufai/*.md` - Updated all UFAI documentation files

## Rationale

Discord is not currently being used for this project, so maintaining these references could confuse users. GitHub Discussions provides a more integrated community platform for this repository.

## Testing

- [x] Verified all Discord references have been removed
- [x] Confirmed GitHub Discussions is properly referenced as alternative
- [x] All documentation remains properly formatted

## Draft PR Notice

This is a **draft PR** to minimize CI costs during review. The PR will be marked as ready once confirmed.